### PR TITLE
Redesign Team Details screen layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/Theme.FootballTeams">
         <activity
             android:name=".details.TeamDetailsActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@style/Theme.TeamDetails"/>
         <activity
             android:name=".main.MainActivity"
             android:exported="true">

--- a/app/src/main/java/ru/bykov/footballteams/details/TeamDetailsActivity.kt
+++ b/app/src/main/java/ru/bykov/footballteams/details/TeamDetailsActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import com.bumptech.glide.Glide
 import ru.bykov.footballteams.R
 import ru.bykov.footballteams.di.TeamDetailsInjection
@@ -34,12 +35,16 @@ class TeamDetailsActivity : AppCompatActivity(), TeamDetailsContract.View {
 
     private lateinit var presenter: TeamDetailsContract.Presenter
 
+    private val toolbar: Toolbar by lazy(LazyThreadSafetyMode.NONE) {
+        findViewById(R.id.toolbar)
+    }
+
     private val teamBadge: ImageView by lazy(LazyThreadSafetyMode.NONE) {
         findViewById(R.id.team_badge)
     }
 
-    private val teamNameLabel: TextView by lazy(LazyThreadSafetyMode.NONE) {
-        findViewById(R.id.team_name_label)
+    private val teamName: TextView by lazy(LazyThreadSafetyMode.NONE) {
+        findViewById(R.id.team_name)
     }
 
     private val national: TextView by lazy(LazyThreadSafetyMode.NONE) {
@@ -54,8 +59,11 @@ class TeamDetailsActivity : AppCompatActivity(), TeamDetailsContract.View {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_team_details)
-
-        supportActionBar?.title = intent.getStringExtra(EXTRA_TEAM_NAME)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayShowTitleEnabled(false)
+        toolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         presenter = injection.presenter
         presenter.loadTeamDetails(intent.getIntExtra(EXTRA_TEAM_ID, NO_TEAM_ID))
@@ -73,8 +81,8 @@ class TeamDetailsActivity : AppCompatActivity(), TeamDetailsContract.View {
             .load(details.badgeUrl)
             .error(R.drawable.ic_launcher_background)
             .into(teamBadge)
-        teamNameLabel.text = details.name
-        national.text = details.national.toString()
+        teamName.text = details.name
+        national.text = details.country
         venue.text = details.venue
     }
 

--- a/app/src/main/res/layout/activity_team_details.xml
+++ b/app/src/main/res/layout/activity_team_details.xml
@@ -1,82 +1,97 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     tools:context=".details.TeamDetailsActivity">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="8dp">
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
-        <ImageView
-            android:id="@+id/team_badge"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:contentDescription="@string/badge_content_description"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintWidth_percent=".3"
-            app:layout_constraintDimensionRatio="1:1"
-            tools:src="@drawable/ic_launcher_background" />
-
-        <TextView
-            android:id="@+id/team_name_label"
-            android:layout_width="wrap_content"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="24sp"
-            android:textAllCaps="true"
-            tools:text="FC Barcelona"
-            app:layout_constraintStart_toEndOf="@id/team_badge"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/team_badge" />
+            android:background="?attr/colorPrimary"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="?attr/actionBarTheme"
+            app:navigationIcon="?attr/homeAsUpIndicator" />
 
-        <TextView
-            android:id="@+id/national_label"
-            style="@style/DetailsLabelStyle"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/national_label"
-            app:layout_constraintStart_toEndOf="@id/team_badge"
-            app:layout_constraintTop_toBottomOf="@id/team_name_label" />
+            android:padding="8dp"
+            app:layout_scrollFlags="scroll|snap">
 
-        <TextView
-            android:id="@+id/national"
-            style="@style/DetailsValueStyle"
-            android:layout_width="wrap_content"
+            <ImageView
+                android:id="@+id/team_badge"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:contentDescription="@string/badge_content_description"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_percent=".2"
+                app:layout_constraintDimensionRatio="1:1"
+                tools:src="@drawable/ic_launcher_background" />
+
+            <TextView
+                android:id="@+id/team_name"
+                style="@style/TeamDetails.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                tools:text="FC Barcelona"
+                app:layout_constraintStart_toEndOf="@id/team_badge"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/national"
+                style="@style/TeamDetails.Subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                app:layout_constraintLeft_toRightOf="@id/team_badge"
+                app:layout_constraintTop_toBottomOf="@id/team_name"
+                tools:text="Spain" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toEndOf="@id/barrier"
-            app:layout_constraintBaseline_toBaselineOf="@id/national_label"
-            tools:text="True" />
+            android:padding="8dp">
 
-        <TextView
-            android:id="@+id/venue_label"
-            style="@style/DetailsLabelStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/venue_label"
-            app:layout_constraintStart_toEndOf="@id/team_badge"
-            app:layout_constraintTop_toBottomOf="@id/national_label" />
+            <TextView
+                android:id="@+id/venue_label"
+                style="@style/TeamDetails.Label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/venue_label"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
 
-        <TextView
-            android:id="@+id/venue"
-            style="@style/DetailsValueStyle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintStart_toEndOf="@id/team_badge"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/venue_label"
-            tools:text="Very very long and not in one line description of a football team" />
+            <TextView
+                android:id="@+id/venue"
+                style="@style/TeamDetails.Value"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/venue_label"
+                tools:text="Very very long and not in one line description of a football team" />
 
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:barrierDirection="end"
-            app:constraint_referenced_ids="venue_label,national_label"/>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="DetailsLabelStyle">
-        <item name="android:layout_marginStart">8dp</item>
-        <item name="android:textSize">16sp</item>
-        <item name="android:textStyle">bold</item>
+    <style name="TeamDetails.Title" parent="TextAppearance.MaterialComponents.Headline5">
+        <item name="android:textColor">@color/white_12</item>
     </style>
 
-    <style name="DetailsValueStyle">
-        <item name="android:layout_marginStart">10dp</item>
-        <item name="android:textSize">16sp</item>
+    <style name="TeamDetails.Subtitle" parent="TextAppearance.MaterialComponents.Subtitle1">
+        <item name="android:textColor">@color/white_12</item>
     </style>
+
+    <style name="TeamDetails.Label" parent="TextAppearance.MaterialComponents.Caption"/>
+
+    <style name="TeamDetails.Value" parent="TextAppearance.MaterialComponents.Body1"/>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,4 +14,20 @@
         <item name="android:navigationBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="Theme.TeamDetails" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Primary brand color. -->
+        <item name="colorPrimary">@color/color_primary</item>
+        <item name="colorPrimaryVariant">@color/color_primary_variant</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <!-- Secondary brand color. -->
+        <item name="colorSecondary">@color/color_secondary</item>
+        <item name="colorSecondaryVariant">@color/color_secondary_variant</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <!-- Status bar color. -->
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+        <item name="android:navigationBarColor">?attr/colorPrimaryVariant</item>
+        <!-- Customize your theme here. -->
+    </style>
+
 </resources>

--- a/app/src/test/java/ru/bykov/footballteams/details/TeamDetailsPresenterTest.kt
+++ b/app/src/test/java/ru/bykov/footballteams/details/TeamDetailsPresenterTest.kt
@@ -104,7 +104,7 @@ private class SuccessRepository : FootballTeamRepository {
 
     override fun details(teamId: Int): Single<FootballTeamDetails> {
         return Single.fromCallable {
-            FootballTeamDetails(1, "FC Barcelona", false, "Mesque un club", "")
+            FootballTeamDetails(1, "FC Barcelona", "Spain", "Mesque un club", "")
         }
     }
 }

--- a/app/src/test/java/ru/bykov/footballteams/main/MainPresenterTest.kt
+++ b/app/src/test/java/ru/bykov/footballteams/main/MainPresenterTest.kt
@@ -107,7 +107,7 @@ private class SuccessRepository : FootballTeamRepository {
 
     override fun details(teamId: Int): Single<FootballTeamDetails> {
         return Single.fromCallable {
-            FootballTeamDetails(1, "FC Barcelona", false, "Mesque un club", "")
+            FootballTeamDetails(1, "FC Barcelona", "Spain", "Mesque un club", "")
         }
     }
 }

--- a/data/src/main/kotlin/ru/bykov/footballteams/entity/FullTeamEntity.kt
+++ b/data/src/main/kotlin/ru/bykov/footballteams/entity/FullTeamEntity.kt
@@ -20,7 +20,7 @@ fun FullTeamEntity.toTeam(): FootballTeam = FootballTeam(
 fun FullTeamEntity.toTeamDetails(): FootballTeamDetails = FootballTeamDetails(
     team.id,
     team.name,
-    team.national,
+    team.country,
     "${venue.name} with capacity ${venue.capacity}", // TODO move to a separate class
     team.logo
 )

--- a/domain/src/main/kotlin/ru/bykov/footballteams/models/FootballTeamDetails.kt
+++ b/domain/src/main/kotlin/ru/bykov/footballteams/models/FootballTeamDetails.kt
@@ -3,7 +3,7 @@ package ru.bykov.footballteams.models
 class FootballTeamDetails(
     val id: Int,
     val name: String,
-    val national: Boolean,
+    val country: String,
     val venue: String,
     val badgeUrl: String
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,9 @@ org.gradle.parallel=true
 # by caching the result of the configuration phase and reusing this for subsequent builds
 # https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.unsafe.configuration-cache=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app"s APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,12 +10,10 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+org.gradle.parallel=true
+# The configuration cache is a feature that significantly improves build performance
+# by caching the result of the configuration phase and reusing this for subsequent builds
+# https://docs.gradle.org/current/userguide/configuration_cache.html
+org.gradle.unsafe.configuration-cache=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/gradle/plugins/plugins-platform/build.gradle.kts
+++ b/gradle/plugins/plugins-platform/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 // Declare versions of the plugins here
 dependencies.constraints {
-    api("com.android.tools.build:gradle:7.4.0")
+    api("com.android.tools.build:gradle:7.4.1")
     api("com.autonomousapps:dependency-analysis-gradle-plugin:1.2.0")
     api("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
     api("de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0")


### PR DESCRIPTION
Design fixes:
- Add AppBarLayout with toolbar.
- Move team name and team country to AppBarLayout and venue info to main section
- Change theme for DetailsActivity to inherit dark toolbar theme
- Change style for textviews on the details screen to inherit MaterialComponents styles

Tools fixes:
- Upgrade AGP to 7.4.1
- Enable parallel gradle execution
- Enable gradle configuration cache

Closes #26 