### PR TITLE
Update teams once a day

### DIFF
--- a/app/src/main/java/ru/bykov/footballteams/di/AppContainer.kt
+++ b/app/src/main/java/ru/bykov/footballteams/di/AppContainer.kt
@@ -4,11 +4,16 @@ import android.content.Context
 import ru.bykov.footballteams.BuildConfig
 import ru.bykov.footballteams.Secrets
 import ru.bykov.footballteams.repository.FootballTeamRepository
+import ru.bykov.footballteams.repository.StringPreferencesRepository
 
 class AppContainer(context: Context) {
 
     private val secrets: Secrets = Secrets()
     private val dataContainer: DataContainer = DataContainer(context)
+
+    val preferencesRepository: StringPreferencesRepository by lazy(LazyThreadSafetyMode.NONE) {
+        dataContainer.stringPreferencesRepository()
+    }
 
     val remoteRepository: FootballTeamRepository by lazy(LazyThreadSafetyMode.NONE) {
         dataContainer.remoteRepository(secrets.getApiFootballKey(BuildConfig.APPLICATION_ID))

--- a/app/src/main/java/ru/bykov/footballteams/di/TeamListContainer.kt
+++ b/app/src/main/java/ru/bykov/footballteams/di/TeamListContainer.kt
@@ -6,6 +6,7 @@ import ru.bykov.footballteams.main.MainContract
 import ru.bykov.footballteams.main.MainPresenter
 import ru.bykov.footballteams.main.TeamListAdapter
 import ru.bykov.footballteams.repository.FootballTeamRepository
+import ru.bykov.footballteams.repository.StringPreferencesRepository
 import ru.bykov.footballteams.ui.DisplayableItem
 import ru.bykov.footballteams.ui.FootballTeamItem
 import ru.bykov.footballteams.ui.FootballTeamsViewHolderFactory
@@ -13,6 +14,7 @@ import ru.bykov.footballteams.ui.OnTeamItemClickListener
 import ru.bykov.footballteams.usecase.GetTeams
 
 class TeamListContainer(
+    private val preferencesRepository: StringPreferencesRepository,
     private val localRepository: FootballTeamRepository,
     private val remoteRepository: FootballTeamRepository,
 ) {
@@ -35,6 +37,7 @@ class TeamListContainer(
     fun presenter(view: MainContract.View): MainContract.Presenter {
         return MainPresenter(
             GetTeams(
+                preferencesRepository,
                 localRepository,
                 remoteRepository
             ),

--- a/app/src/main/java/ru/bykov/footballteams/main/MainActivity.kt
+++ b/app/src/main/java/ru/bykov/footballteams/main/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import ru.bykov.footballteams.FooteaApplication
 import ru.bykov.footballteams.R
 import ru.bykov.footballteams.details.showTeamDetails
@@ -23,10 +22,6 @@ class MainActivity : AppCompatActivity(), MainContract.View, OnTeamItemClickList
         findViewById(R.id.teams_recycler)
     }
 
-    private val swipeRefreshLayout: SwipeRefreshLayout by lazy(LazyThreadSafetyMode.NONE) {
-        findViewById(R.id.swipe_refresh_layout)
-    }
-
     private val progressBar: ProgressBar by lazy(LazyThreadSafetyMode.NONE) {
         findViewById(R.id.progress_bar)
     }
@@ -42,6 +37,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, OnTeamItemClickList
 
         appContainer = (application as FooteaApplication).appContainer
         appContainer.teamListContainer = TeamListContainer(
+            appContainer.preferencesRepository,
             appContainer.localRepository,
             appContainer.remoteRepository,
         )
@@ -49,10 +45,6 @@ class MainActivity : AppCompatActivity(), MainContract.View, OnTeamItemClickList
         adapter = appContainer.teamListContainer!!.adapter(this, this)
 
         teamsRecycler.adapter = adapter
-
-        swipeRefreshLayout.setOnRefreshListener {
-            presenter.refreshTeams()
-        }
 
         presenter.loadTeams()
     }
@@ -70,7 +62,6 @@ class MainActivity : AppCompatActivity(), MainContract.View, OnTeamItemClickList
     }
 
     override fun showContent(teams: List<FootballTeamItem>) {
-        swipeRefreshLayout.isRefreshing = false
         progressBar.gone()
         teamsRecycler.show()
         adapter.setItems(teams)
@@ -78,7 +69,6 @@ class MainActivity : AppCompatActivity(), MainContract.View, OnTeamItemClickList
 
     override fun showError() {
         progressBar.gone()
-        swipeRefreshLayout.isRefreshing = false
         toast(getString(R.string.default_error))
     }
     // endregion

--- a/app/src/main/java/ru/bykov/footballteams/main/MainContract.kt
+++ b/app/src/main/java/ru/bykov/footballteams/main/MainContract.kt
@@ -12,7 +12,6 @@ object MainContract {
 
     interface Presenter {
         fun loadTeams()
-        fun refreshTeams()
         fun destroy()
     }
 }

--- a/app/src/main/java/ru/bykov/footballteams/main/MainPresenter.kt
+++ b/app/src/main/java/ru/bykov/footballteams/main/MainPresenter.kt
@@ -5,10 +5,10 @@ import io.reactivex.disposables.CompositeDisposable
 import ru.bykov.footballteams.extensions.async
 import ru.bykov.footballteams.models.FootballTeam
 import ru.bykov.footballteams.ui.FootballTeamItem
-import ru.bykov.footballteams.usecase.UseCase
+import ru.bykov.footballteams.usecase.SimpleUseCase
 
 class MainPresenter(
-    private val getTeams: UseCase<Single<List<FootballTeam>>, Boolean>,
+    private val getTeams: SimpleUseCase<Single<List<FootballTeam>>>,
     private val view: MainContract.View,
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
 ) : MainContract.Presenter {
@@ -29,22 +29,12 @@ class MainPresenter(
 
     }
 
-    override fun refreshTeams() {
-        compositeDisposable.add(
-            loadFootballTeams(forceUpdate = true)
-                .subscribe(
-                    { view.showContent(it) },
-                    { view.showError() }
-                )
-        )
-    }
-
     override fun destroy() {
         compositeDisposable.clear()
     }
 
-    private fun loadFootballTeams(forceUpdate: Boolean = false): Single<List<FootballTeamItem>> {
-        return getTeams(forceUpdate)
+    private fun loadFootballTeams(): Single<List<FootballTeamItem>> {
+        return getTeams()
             .map { teams -> teams.map { FootballTeamItem(it) } }
             .async()
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,37 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".main.MainActivity">
 
-    <FrameLayout
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_gravity="center"
+        android:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/teams_recycler"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="6dp"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:spanCount="2"
+        tools:listitem="@layout/item_football_team"
+        tools:visibility="visible" />
 
-        <ProgressBar
-            android:id="@+id/progress_bar"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_gravity="center"
-            android:visibility="visible" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/teams_recycler"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"
-            android:clipToPadding="false"
-            android:padding="6dp"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="2"
-            tools:listitem="@layout/item_football_team"
-            tools:visibility="visible" />
-
-    </FrameLayout>
-
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
+</FrameLayout>

--- a/app/src/test/java/ru/bykov/footballteams/main/MainPresenterTest.kt
+++ b/app/src/test/java/ru/bykov/footballteams/main/MainPresenterTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import ru.bykov.footballteams.RxSchedulersOverrideRule
 import ru.bykov.footballteams.models.FootballTeam
 import ru.bykov.footballteams.ui.FootballTeamItem
-import ru.bykov.footballteams.usecase.UseCase
+import ru.bykov.footballteams.usecase.SimpleUseCase
 
 @ExtendWith(RxSchedulersOverrideRule::class)
 internal class MainPresenterTest {
@@ -98,16 +98,16 @@ private class MockView : MainContract.View {
 
 }
 
-private class SuccessGetTeams : UseCase<Single<List<FootballTeam>>, Boolean> {
+private class SuccessGetTeams : SimpleUseCase<Single<List<FootballTeam>>> {
 
-    override fun invoke(forceUpdate: Boolean): Single<List<FootballTeam>> {
+    override fun invoke(): Single<List<FootballTeam>> {
         return Single.just(listOf(FootballTeam(1, "FC Barcelona", "")))
     }
 }
 
-private class FailedGetTeams : UseCase<Single<List<FootballTeam>>, Boolean> {
+private class FailedGetTeams : SimpleUseCase<Single<List<FootballTeam>>> {
 
-    override fun invoke(forceUpdate: Boolean): Single<List<FootballTeam>> {
+    override fun invoke(): Single<List<FootballTeam>> {
         return Single.error(Throwable("Data not loaded"))
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -16,4 +16,7 @@ dependencies {
     implementation("com.squareup.retrofit2:adapter-rxjava2")
     implementation("com.squareup.retrofit2:converter-gson")
     implementation("com.squareup.okhttp3:logging-interceptor")
+
+    // Mocks
+    testImplementation("io.mockk:mockk")
 }

--- a/data/src/main/kotlin/ru/bykov/footballteams/di/DataContainer.kt
+++ b/data/src/main/kotlin/ru/bykov/footballteams/di/DataContainer.kt
@@ -14,8 +14,12 @@ import ru.bykov.footballteams.network.TeamsApi
 import ru.bykov.footballteams.repository.FootballTeamRepository
 import ru.bykov.footballteams.repository.LocalFirstFootballTeamRepository
 import ru.bykov.footballteams.repository.RemoteFootballTeamRepository
+import ru.bykov.footballteams.repository.StringPreferencesRepository
+import ru.bykov.footballteams.repository.StringSharedPreferencesRepository
 
 private const val BASE_URL = "https://v3.football.api-sports.io"
+
+private const val STRING_PREFS_NAME = "rx_string_prefs"
 
 class DataContainer(private val context: Context) {
 
@@ -64,6 +68,11 @@ class DataContainer(private val context: Context) {
         return retrofit(apiKey).create(TeamsApi::class.java)
     }
 
+    fun stringPreferencesRepository(): StringPreferencesRepository {
+        return StringSharedPreferencesRepository(
+            context.getSharedPreferences(STRING_PREFS_NAME, Context.MODE_PRIVATE)
+        )
+    }
 
     fun remoteRepository(apiKey: String): FootballTeamRepository {
         return RemoteFootballTeamRepository(

--- a/data/src/main/kotlin/ru/bykov/footballteams/repository/StringSharedPreferencesRepository.kt
+++ b/data/src/main/kotlin/ru/bykov/footballteams/repository/StringSharedPreferencesRepository.kt
@@ -1,0 +1,30 @@
+package ru.bykov.footballteams.repository
+
+import android.content.SharedPreferences
+import io.reactivex.Completable
+import io.reactivex.Single
+
+class StringSharedPreferencesRepository(
+    private val sharedPreferences: SharedPreferences
+) : StringPreferencesRepository {
+
+    override fun getPref(key: String, defaultValue: String): Single<String> {
+        return Single.fromCallable {
+            sharedPreferences.getString(key, defaultValue)
+        }
+    }
+
+    override fun setPref(key: String, value: String): Completable {
+        return Single
+            .fromCallable {
+                sharedPreferences.edit().putString(key, value).commit()
+            }
+            .flatMapCompletable {
+                if (it) {
+                    Completable.complete()
+                } else {
+                    Completable.error(Throwable("Error while saving to shared preferences"))
+                }
+            }
+    }
+}

--- a/data/src/test/kotlin/ru/bykov/footballteams/usecase/GetTeamsTest.kt
+++ b/data/src/test/kotlin/ru/bykov/footballteams/usecase/GetTeamsTest.kt
@@ -1,0 +1,88 @@
+package ru.bykov.footballteams.usecase
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.reactivex.Completable
+import io.reactivex.Single
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.junit.jupiter.api.Test
+import ru.bykov.footballteams.models.FootballTeam
+import ru.bykov.footballteams.repository.FootballTeamRepository
+import ru.bykov.footballteams.repository.StringPreferencesRepository
+
+internal class GetTeamsTest {
+
+    private val localRepository = mockk<FootballTeamRepository>()
+    private val remoteRepository = mockk<FootballTeamRepository>()
+
+    @Test
+    internal fun `should load remote teams when first time get teams`() {
+        // given
+        val expectedTeams = listOf(
+            FootballTeam(1, "Team 1", "Logo 1"),
+            FootballTeam(2, "Team 2", "Logo 2")
+        )
+        every { remoteRepository.teams() } returns Single.just(expectedTeams)
+        val getTeams = GetTeams(
+            DistantPastLastUpdateDateRepository(),
+            localRepository,
+            remoteRepository
+        )
+
+        // when
+        val teams = getTeams.invoke().test()
+
+
+        // then
+        teams.assertValue(expectedTeams)
+
+        verify(exactly = 0) { localRepository.teams() }
+        verify(exactly = 1) { remoteRepository.teams() }
+    }
+
+    @Test
+    internal fun `should load local teams when last update date is within one day`() {
+        // given
+        val expectedTeams = listOf(
+            FootballTeam(1, "Team 1", "Logo 1"),
+            FootballTeam(2, "Team 2", "Logo 2")
+        )
+        every { localRepository.teams() } returns Single.just(expectedTeams)
+        val getTeams = GetTeams(
+            WithinDayLastUpdateDateRepository(),
+            localRepository,
+            remoteRepository
+        )
+
+        // when
+        val teams = getTeams().test()
+
+        // then
+        teams.assertValue(expectedTeams)
+        verify(exactly = 1) { localRepository.teams() }
+        verify(exactly = 0) { remoteRepository.teams() }
+    }
+}
+
+private class WithinDayLastUpdateDateRepository : StringPreferencesRepository {
+
+    override fun getPref(key: String, defaultValue: String): Single<String> {
+        return Single.just(Clock.System.now().toString())
+    }
+
+    override fun setPref(key: String, value: String): Completable {
+        return Completable.complete()
+    }
+}
+
+private class DistantPastLastUpdateDateRepository : StringPreferencesRepository {
+    override fun getPref(key: String, defaultValue: String): Single<String> {
+        return Single.just(Instant.DISTANT_PAST.toString())
+    }
+
+    override fun setPref(key: String, value: String): Completable {
+        return Completable.complete()
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -6,4 +6,7 @@ dependencies {
 
     // Rx
     api("io.reactivex.rxjava2:rxjava")
+
+    // kotlinx datetime
+    api("org.jetbrains.kotlinx:kotlinx-datetime")
 }

--- a/domain/src/main/kotlin/ru/bykov/footballteams/repository/StringPreferencesRepository.kt
+++ b/domain/src/main/kotlin/ru/bykov/footballteams/repository/StringPreferencesRepository.kt
@@ -1,0 +1,11 @@
+package ru.bykov.footballteams.repository
+
+import io.reactivex.Completable
+import io.reactivex.Single
+
+interface StringPreferencesRepository {
+
+    fun getPref(key: String, defaultValue: String): Single<String>
+    fun setPref(key: String, value: String): Completable
+
+}

--- a/domain/src/main/kotlin/ru/bykov/footballteams/usecase/GetTeams.kt
+++ b/domain/src/main/kotlin/ru/bykov/footballteams/usecase/GetTeams.kt
@@ -1,21 +1,36 @@
 package ru.bykov.footballteams.usecase
 
 import io.reactivex.Single
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toInstant
 import ru.bykov.footballteams.models.FootballTeam
 import ru.bykov.footballteams.repository.FootballTeamRepository
+import ru.bykov.footballteams.repository.StringPreferencesRepository
 
-// TODO add pref to get teams from remote only once a day
+private const val LAST_UPDATE_DATE = "last_update_date"
 class GetTeams(
+    private val prefsRepository: StringPreferencesRepository,
     private val localRepository: FootballTeamRepository,
     private val remoteRepository: FootballTeamRepository
-) : UseCase<Single<List<FootballTeam>>, Boolean>{
+) : SimpleUseCase<Single<List<FootballTeam>>>{
 
-    @Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
-    override fun invoke(forceUpdate: Boolean): Single<List<FootballTeam>> {
-        return if (forceUpdate) {
-            remoteRepository.teams()
-        } else {
-            localRepository.teams()
+    override fun invoke(): Single<List<FootballTeam>> {
+        return prefsRepository.getPref(LAST_UPDATE_DATE, Instant.DISTANT_PAST.toString())
+            .flatMap { lastUpdateDate ->
+                val diff = Clock.System.now() - lastUpdateDate.toInstant()
+                if (diff.isPositive() && diff.inWholeDays > 1) {
+                    getRemoteTeams()
+                } else {
+                    localRepository.teams()
+                }
+            }
+    }
+
+    private fun getRemoteTeams(): Single<List<FootballTeam>> {
+        return remoteRepository.teams().flatMap { teams ->
+            prefsRepository.setPref(LAST_UPDATE_DATE, Clock.System.now().toString())
+                .andThen(Single.just(teams))
         }
     }
 }

--- a/domain/src/main/kotlin/ru/bykov/footballteams/usecase/UseCase.kt
+++ b/domain/src/main/kotlin/ru/bykov/footballteams/usecase/UseCase.kt
@@ -4,3 +4,8 @@ fun interface UseCase<out Type, in Params> {
 
     operator fun invoke(params: Params): Type
 }
+
+fun interface SimpleUseCase<out Type> {
+
+    operator fun invoke(): Type
+}

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(platform("org.junit:junit-bom:5.7.2")) { (this as ExternalModuleDependency).version { reject("[5.8.0,)") } } // Do not Upgrade to 5.8: https://github.com/gradle/gradle/issues/18627
+    api(platform("org.junit:junit-bom:5.8.2"))
     api(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
 }
 
@@ -32,6 +32,9 @@ dependencies.constraints {
     api("androidx.room:room-rxjava2:$roomVersion")
     api("androidx.room:room-compiler:$roomVersion")
 
+    // Datetime
+    api("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
+
     // UI
     api("androidx.constraintlayout:constraintlayout:2.1.1")
     api("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
@@ -45,6 +48,7 @@ dependencies.constraints {
     // (Required) Writing and executing Unit Tests on the JUnit Platform
     api("io.kotest:kotest-runner-junit5:4.6.3")
     api("io.kotest:kotest-assertions-core:4.6.3")
+    api("io.mockk:mockk:1.13.4")
 
     // UI tests
     api("androidx.test.ext:junit:1.1.3")


### PR DESCRIPTION
[Add repository abstraction for string preferences](https://github.com/grine4ka/footea/commit/0b070d405e2b3a7215e692c43fb2651f4424a10d) 

- Add interface StringPreferencesRepository to domain module and its implementation based on shared preferences to data module

[Update teams only once a day](https://github.com/grine4ka/footea/commit/c0cf3d49edaf8181c77d9d5adab2cffed0033752) 

- Add logic for updating teams once a day in GetTeams use case and write tests for it
- Remove SwipeRefreshLayout from the main screen to stop forcing updating of the teams list
- Add mockk library for tests
- Add kotlinx-datetime library for working with dates and time

Closes #34 